### PR TITLE
Fix maptype setter

### DIFF
--- a/src/Generators/UrlGenerator.php
+++ b/src/Generators/UrlGenerator.php
@@ -57,7 +57,7 @@ class URLGenerator implements GeneratorInterface{
 
     //maptype
     if (($maptype = $this->map->getMaptype()) !== null) {
-      $this->parameters['maptype'] = $this->maptype;
+      $this->parameters['maptype'] = $maptype;
     }
 
     //maptype


### PR DESCRIPTION
There is no maptype property in UrlGenerator class. When you try to set maptype:
[Notice] Undefined property: Tidusvn05\StaticMap\Generators\URLGenerator::$maptype